### PR TITLE
Fixed chat bug in lobby where disconnecting sockets wouldn't use session.user

### DIFF
--- a/routes/lobby.js
+++ b/routes/lobby.js
@@ -1,8 +1,7 @@
 module.exports = function(db, io) {
   let express = require('express');
   let router = express.Router();
-  let username;
-  let session;
+  var session;
   const dbjs = require('./database')
   const database = new dbjs(db)
   const { UPDATEGAMELIST } = require('../constants/events')
@@ -13,7 +12,7 @@ module.exports = function(db, io) {
     session = request.session;
 
     if(session.user) {
-      username = session.user;
+      let username = session.user;
       response.render('lobby', { USERNAME: username });
     }
     else {
@@ -22,32 +21,36 @@ module.exports = function(db, io) {
   });
 
   router.post('/', function(request, response, next) {
-    username  = request.body.username;
+    let username  = request.body.username;
 
     response.render('lobby', { USERNAME: username });
   });
 
   io.on('connection', function(socket) {
     console.log("A user connected to /");
+    
     socket.on('disconnect', function() {
     console.log("user disconnected from /");
     });
   });
 
   var lobby_io = io.of('/lobby');
-  console.log("namespace: " + lobby_io);
-  
   lobby_io.on('connection', function(socket) {
-    console.log("A user connected to /lobby namespace");
+    var username;
+    if(session != null) {
+      username = session.user;
+    }
+    
+    console.log(username + " connected to /lobby namespace");
     
     require('./gameserver').broadcastGameList(lobby_io);
     lobby_io.emit("user_entered_chat", "User " + username + " has entered the room...");
     
     socket.on('chat_sent', function(message) {
-     username = message.substr(0,message.indexOf(' '));
-     message = message.substr(message.indexOf(' ')+1);
+     user = message.substr(0,message.indexOf(' '));
+     msg = message.substr(message.indexOf(' ')+1);
 
-      lobby_io.emit('chat_received', username + ": " + message);
+      lobby_io.emit('chat_received', username + ": " + msg);
     });
 
     socket.on('disconnect', function() {


### PR DESCRIPTION
because the username variable was modified somewhere in between connecting
and disconnecting. The reason was because the variable was declared as
global let, and thus allowed to be modified by inner function blocks.